### PR TITLE
feat: add git identity with conditional work email

### DIFF
--- a/git/.gitconfig
+++ b/git/.gitconfig
@@ -1,3 +1,10 @@
+[user]
+    name = Tristan Tibbs
+    email = tristantibbs@gmail.com
+
+[includeIf "gitdir:~/Work/"]
+    path = ~/.gitconfig-work
+
 [init]
     defaultBranch = main
 

--- a/git/.gitconfig-work
+++ b/git/.gitconfig-work
@@ -1,0 +1,2 @@
+[user]
+    email = tristan.tibbs@plexus.com

--- a/git/install.sh
+++ b/git/install.sh
@@ -23,9 +23,12 @@ if [ -f "$HOME/.gitconfig" ] && [ ! -L "$HOME/.gitconfig" ]; then
     mv "$HOME/.gitconfig" "$HOME/.gitconfig.backup"
 fi
 
-# Create symlink
+# Create symlinks
 ln -sf "$SCRIPT_DIR/.gitconfig" "$HOME/.gitconfig"
 echo -e "${GREEN}  ✓ Linked .gitconfig${NC}"
+
+ln -sf "$SCRIPT_DIR/.gitconfig-work" "$HOME/.gitconfig-work"
+echo -e "${GREEN}  ✓ Linked .gitconfig-work${NC}"
 
 echo ""
 echo -e "${GREEN}✅ Git configuration installed!${NC}"


### PR DESCRIPTION
## Summary
- Add git user identity (name + email) to shared config
- Add conditional include for ~/Work/ directory with work email
- Install script symlinks both config files

Uses `includeIf` to auto-switch identity based on directory.