### PR TITLE
fix: enable OSC 52 clipboard for tmux

### DIFF
--- a/tmux/.tmux.conf
+++ b/tmux/.tmux.conf
@@ -18,6 +18,9 @@ bind C-a send-prefix
 # Enable mouse support
 set -g mouse on
 
+# Enable OSC 52 clipboard - auto-copy selection to system clipboard
+set -g set-clipboard external
+
 # Set default terminal mode with true color and UTF-8 support
 set -g default-terminal "tmux-256color"
 set-option -ga terminal-overrides ",xterm-256color:Tc"


### PR DESCRIPTION
## Summary
- Add `set -g set-clipboard external` to enable OSC 52 clipboard support
- Auto-copies mouse selection to system clipboard without requiring manual yank
- Fixes clipboard clearing when clicking away and back to WezTerm

Closes #18