### PR TITLE
feat: add AI CLI aliases for Claude and Gemini

### DIFF
--- a/zsh/aliash.zsh
+++ b/zsh/aliash.zsh
@@ -41,14 +41,14 @@ else
 fi
 
 # Claude Code aliases
-if command -v claude >/dev/null 2>&1; then
+if command -v claude &>/dev/null; then
   alias cc='claude --dangerously-skip-permissions'
   alias ccc='claude --dangerously-skip-permissions -c'
 fi
 
-# Gemini CLI aliases
-if command -v gemini >/dev/null 2>&1; then
-  alias gem='gemini --model gemini-2.5-flash'
+# Gemini CLI aliases (gf = gemini flash, avoids conflict with Ruby's gem)
+if command -v gemini &>/dev/null; then
+  alias gf='gemini --model gemini-2.5-flash'
 fi
 
 # Source getcontext functions if available


### PR DESCRIPTION
## Summary
- Add shell aliases for frequently-used AI CLI commands
- Reduces typing for common workflows

## Aliases
| Alias | Command | Description |
|-------|---------|-------------|
| `cc` | `claude --dangerously-skip-permissions` | Claude Code with permissions skipped |
| `ccc` | `claude --dangerously-skip-permissions -c` | Claude Code continue mode |
| `gf` | `gemini --model gemini-2.5-flash` | Gemini CLI with 2.5 Flash model |

## Usage
```bash
cc           # Start Claude Code
ccc          # Continue previous Claude session
gf           # Start Gemini with Flash model
```