### PR TITLE
feat: add treemd and mcat for markdown tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ cd dotfiles
 | `fzf`  | -            | Fuzzy finder for command-line                   |
 | `fastfetch` | `neofetch` | Fast system info display                    |
 | `repomix` | -            | Pack repo into AI-friendly file             |
+| `mcat`  | -              | Render markdown in terminal                   |
+| `treemd`| `tree`         | Generate markdown directory trees             |
 
 ## AI CLI Aliases
 

--- a/homebrew/Brewfile
+++ b/homebrew/Brewfile
@@ -15,7 +15,9 @@ brew "git-delta"     # Git syntax highlighting
 brew "lazydocker"    # Docker TUI
 brew "mikescher/tap/dops"  # Better docker ps
 brew "procs"         # Better ps
+brew "mcat"          # Markdown cat
 brew "repomix"       # AI context generation
+brew "treemd"        # Markdown directory trees
 brew "starship"      # Shell prompt
 brew "tldr"          # Simplified man pages
 brew "tmux"          # Terminal multiplexer

--- a/install/linux/common-tools.sh
+++ b/install/linux/common-tools.sh
@@ -50,3 +50,26 @@ elif command -v npm &>/dev/null; then
 else
     echo "⚠️  npm not found - skipping repomix install"
 fi
+
+# Install Rust-based tools via cargo
+if command -v cargo &>/dev/null; then
+    # mcat - Markdown cat
+    if command -v mcat &>/dev/null; then
+        echo "✅ mcat is already installed"
+    else
+        echo "📦 Installing mcat via cargo..."
+        cargo install mcat
+        echo "✅ mcat installed"
+    fi
+
+    # treemd - Markdown directory trees
+    if command -v treemd &>/dev/null; then
+        echo "✅ treemd is already installed"
+    else
+        echo "📦 Installing treemd via cargo..."
+        cargo install treemd
+        echo "✅ treemd installed"
+    fi
+else
+    echo "⚠️  cargo not found - skipping mcat and treemd install"
+fi


### PR DESCRIPTION
## Summary
- Add treemd and mcat to Brewfile for macOS
- Add cargo install for Linux
- Update README CLI Tools table

Closes #39