### PR TITLE
feat: add onefetch for git repo info display

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ cd dotfiles
 | `repomix` | -            | Pack repo into AI-friendly file             |
 | `mcat`  | -              | Render markdown in terminal                   |
 | `treemd`| `tree`         | Generate markdown directory trees             |
+| `onefetch`| -            | Git repo info display (like neofetch for repos)|
 
 ## AI CLI Aliases
 

--- a/homebrew/Brewfile
+++ b/homebrew/Brewfile
@@ -16,6 +16,7 @@ brew "lazydocker"    # Docker TUI
 brew "mikescher/tap/dops"  # Better docker ps
 brew "procs"         # Better ps
 brew "mcat"          # Markdown cat
+brew "onefetch"      # Git repo info display
 brew "repomix"       # AI context generation
 brew "treemd"        # Markdown directory trees
 brew "starship"      # Shell prompt

--- a/install/linux/common-tools.sh
+++ b/install/linux/common-tools.sh
@@ -70,6 +70,15 @@ if command -v cargo &>/dev/null; then
         cargo install treemd
         echo "✅ treemd installed"
     fi
+
+    # onefetch - Git repo info display
+    if command -v onefetch &>/dev/null; then
+        echo "✅ onefetch is already installed"
+    else
+        echo "📦 Installing onefetch via cargo..."
+        cargo install onefetch
+        echo "✅ onefetch installed"
+    fi
 else
-    echo "⚠️  cargo not found - skipping mcat and treemd install"
+    echo "⚠️  cargo not found - skipping mcat, treemd, and onefetch install"
 fi


### PR DESCRIPTION
## Summary
- Add onefetch to Brewfile for macOS
- Add cargo install for Linux
- Update README CLI Tools table

Closes #35