### PR TITLE
feat: add yazi terminal file manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ cd dotfiles
 | `mcat`  | -              | Render markdown in terminal                   |
 | `treemd`| `tree`         | Generate markdown directory trees             |
 | `onefetch`| -            | Git repo info display (like neofetch for repos)|
+| `yazi`  | -              | Terminal file manager with previews             |
 
 ## AI CLI Aliases
 

--- a/homebrew/Brewfile
+++ b/homebrew/Brewfile
@@ -19,6 +19,7 @@ brew "mcat"          # Markdown cat
 brew "onefetch"      # Git repo info display
 brew "repomix"       # AI context generation
 brew "treemd"        # Markdown directory trees
+brew "yazi"          # Terminal file manager
 brew "starship"      # Shell prompt
 brew "tldr"          # Simplified man pages
 brew "tmux"          # Terminal multiplexer

--- a/install/linux/common-tools.sh
+++ b/install/linux/common-tools.sh
@@ -79,6 +79,15 @@ if command -v cargo &>/dev/null; then
         cargo install onefetch
         echo "✅ onefetch installed"
     fi
+
+    # yazi - Terminal file manager
+    if command -v yazi &>/dev/null; then
+        echo "✅ yazi is already installed"
+    else
+        echo "📦 Installing yazi via cargo..."
+        cargo install --locked yazi-fm yazi-cli
+        echo "✅ yazi installed"
+    fi
 else
-    echo "⚠️  cargo not found - skipping mcat, treemd, and onefetch install"
+    echo "⚠️  cargo not found - skipping Rust tools (mcat, treemd, onefetch, yazi)"
 fi

--- a/zsh/aliash.zsh
+++ b/zsh/aliash.zsh
@@ -51,6 +51,18 @@ if command -v gemini &>/dev/null; then
   alias gf='gemini --model gemini-2.5-flash'
 fi
 
+# yazi - cd to directory on exit
+if command -v yazi &>/dev/null; then
+  function y() {
+    local tmp="$(mktemp -t "yazi-cwd.XXXXXX")"
+    yazi "$@" --cwd-file="$tmp"
+    if cwd="$(cat -- "$tmp")" && [ -n "$cwd" ] && [ "$cwd" != "$PWD" ]; then
+      cd -- "$cwd"
+    fi
+    rm -f -- "$tmp"
+  }
+fi
+
 # Source getcontext functions if available
 # Try multiple possible locations for the dotfiles
 if [[ -f "${0:A:h}/../scripts/getcontext.zsh" ]]; then


### PR DESCRIPTION
## Summary
- Add yazi to Brewfile for macOS
- Add cargo install for Linux (with --locked flag)
- Add shell function `y` for cd to directory on exit
- Update README CLI Tools table

## Usage
```bash
yazi        # open file manager
y           # open and cd to selected dir on exit
```

Closes #38