### PR TITLE
fix: correct yazi cargo install command for Linux

### DIFF
--- a/install/linux/common-tools.sh
+++ b/install/linux/common-tools.sh
@@ -84,8 +84,8 @@ if command -v cargo &>/dev/null; then
     if command -v yazi &>/dev/null; then
         echo "✅ yazi is already installed"
     else
-        echo "📦 Installing yazi via cargo..."
-        cargo install --locked yazi-fm yazi-cli
+        echo "📦 Installing yazi via cargo (this may take a while)..."
+        cargo install --force yazi-build
         echo "✅ yazi installed"
     fi
 else


### PR DESCRIPTION
## Summary
- Fixes yazi installation on Linux - requires `yazi-build` wrapper due to Cargo limitations
- Adds note that cargo installs may take a while

The previous command `cargo install --locked yazi-fm yazi-cli` fails with:
> Due to Cargo's limitations, the yazi-fm and yazi-cli crates must be built with cargo install --force yazi-build