### PR TITLE
feat: add GitLens extension and explorer file nesting

### DIFF
--- a/docs/vscode.md
+++ b/docs/vscode.md
@@ -65,6 +65,7 @@ Visual noise is aggressively removed:
 | Menu bar | Toggle (hidden by default) |
 | Command center | Off |
 | Startup editor | None |
+| File nesting | On, collapsed (groups lock files, config variants, etc.) |
 
 ---
 
@@ -139,6 +140,7 @@ Installed automatically on **full profile** machines:
 | `ms-vscode-remote.remote-wsl` | WSL remote development |
 | `ms-vscode.remote-explorer` | Remote connections sidebar |
 | `bierner.markdown-mermaid` | Mermaid diagram rendering in markdown preview |
+| `eamodio.gitlens` | Inline blame, file history, line history, branch compare |
 
 Extensions only install when `code` is on PATH. Failures are non-fatal.
 

--- a/home/.chezmoiscripts/run_once_before_02-install-gui-apps.sh.tmpl
+++ b/home/.chezmoiscripts/run_once_before_02-install-gui-apps.sh.tmpl
@@ -88,6 +88,7 @@ if command -v code &>/dev/null; then
         "ms-vscode-remote.remote-wsl"
         "ms-vscode.remote-explorer"
         "bierner.markdown-mermaid"
+        "eamodio.gitlens"
     )
     for ext in "${VSCODE_EXTENSIONS[@]}"; do
         if code --install-extension "$ext" --force &>/dev/null; then

--- a/home/.chezmoiscripts/run_once_before_install-packages-windows.ps1.tmpl
+++ b/home/.chezmoiscripts/run_once_before_install-packages-windows.ps1.tmpl
@@ -216,7 +216,8 @@ if (Test-Command code) {
         "ms-vscode-remote.remote-containers",
         "ms-vscode-remote.remote-wsl",
         "ms-vscode.remote-explorer",
-        "bierner.markdown-mermaid"
+        "bierner.markdown-mermaid",
+        "eamodio.gitlens"
     )
     foreach ($ext in $VsCodeExtensions) {
         Write-Host "  Installing $ext..." -ForegroundColor Yellow

--- a/home/AppData/Roaming/Code/User/settings.json.tmpl
+++ b/home/AppData/Roaming/Code/User/settings.json.tmpl
@@ -149,6 +149,8 @@
     "workbench.tips.enabled": false,
     "workbench.editor.empty.hint": "hidden",
     "workbench.startupEditor": "none",
+    "explorer.fileNesting.enabled": true,
+    "explorer.fileNesting.expand": false,
     "window.density.editorTabHeight": "compact",
     "window.commandCenter": false,
     "window.menuBarVisibility": "toggle",

--- a/home/Library/Application Support/Code/User/settings.json.tmpl
+++ b/home/Library/Application Support/Code/User/settings.json.tmpl
@@ -149,6 +149,8 @@
     "workbench.tips.enabled": false,
     "workbench.editor.empty.hint": "hidden",
     "workbench.startupEditor": "none",
+    "explorer.fileNesting.enabled": true,
+    "explorer.fileNesting.expand": false,
     "window.density.editorTabHeight": "compact",
     "window.commandCenter": false,
     "window.menuBarVisibility": "toggle",

--- a/home/private_dot_config/Code/User/settings.json.tmpl
+++ b/home/private_dot_config/Code/User/settings.json.tmpl
@@ -149,6 +149,8 @@
     "workbench.tips.enabled": false,
     "workbench.editor.empty.hint": "hidden",
     "workbench.startupEditor": "none",
+    "explorer.fileNesting.enabled": true,
+    "explorer.fileNesting.expand": false,
     "window.density.editorTabHeight": "compact",
     "window.commandCenter": false,
     "window.menuBarVisibility": "toggle",


### PR DESCRIPTION
## Summary

- Add `eamodio.gitlens` to install scripts (macOS/Linux and Windows)
- Enable `explorer.fileNesting` (collapsed by default) across all platforms
- Update VS Code docs with new extension and layout setting