### PR TITLE
fix: persist GitLens AI settings across platforms

### DIFF
--- a/home/AppData/Roaming/Code/User/settings.json.tmpl
+++ b/home/AppData/Roaming/Code/User/settings.json.tmpl
@@ -187,5 +187,9 @@
     "editor.accessibilitySupport": "off",
     "editor.linkedEditing": true,
     "files.trimTrailingWhitespace": true,
-    "explorer.openEditors.visible": 1
+    "explorer.openEditors.visible": 1,
+
+    // ── GitLens ───────────────────────────────────────────────────────────────
+    "gitlens.ai.model": "vscode",
+    "gitlens.ai.vscode.model": "copilot:gpt-4.1"
 }

--- a/home/Library/Application Support/Code/User/settings.json.tmpl
+++ b/home/Library/Application Support/Code/User/settings.json.tmpl
@@ -187,5 +187,9 @@
     "editor.accessibilitySupport": "off",
     "editor.linkedEditing": true,
     "files.trimTrailingWhitespace": true,
-    "explorer.openEditors.visible": 1
+    "explorer.openEditors.visible": 1,
+
+    // ── GitLens ───────────────────────────────────────────────────────────────
+    "gitlens.ai.model": "vscode",
+    "gitlens.ai.vscode.model": "copilot:gpt-4.1"
 }

--- a/home/private_dot_config/Code/User/settings.json.tmpl
+++ b/home/private_dot_config/Code/User/settings.json.tmpl
@@ -187,5 +187,9 @@
     "editor.accessibilitySupport": "off",
     "editor.linkedEditing": true,
     "files.trimTrailingWhitespace": true,
-    "explorer.openEditors.visible": 1
+    "explorer.openEditors.visible": 1,
+
+    // ── GitLens ───────────────────────────────────────────────────────────────
+    "gitlens.ai.model": "vscode",
+    "gitlens.ai.vscode.model": "copilot:gpt-4.1"
 }


### PR DESCRIPTION
## Summary

- Add `gitlens.ai.model` and `gitlens.ai.vscode.model` to all 3 platform settings templates
- Prevents chezmoi from overwriting GitLens AI config on apply