### PR TITLE
fix: correct tar extraction for fastfetch and onefetch on Linux

### DIFF
--- a/home/.chezmoiscripts/run_once_before_01-install-cli-tools.sh.tmpl
+++ b/home/.chezmoiscripts/run_once_before_01-install-cli-tools.sh.tmpl
@@ -195,10 +195,10 @@ if ! command -v fastfetch &>/dev/null; then
     if V=$(gh_version "fastfetch-cli/fastfetch"); then
         if [ "$ARCH" = "x86_64" ]; then
             curl -sL "https://github.com/fastfetch-cli/fastfetch/releases/download/${V}/fastfetch-linux-amd64.tar.gz" \
-                | tar xz --strip-components=1 -C "$HOME/.local/bin" "fastfetch-linux-amd64/usr/bin/fastfetch"
+                | tar xz --strip-components=3 -C "$HOME/.local/bin" "fastfetch-linux-amd64/usr/bin/fastfetch"
         elif [ "$ARCH" = "aarch64" ]; then
             curl -sL "https://github.com/fastfetch-cli/fastfetch/releases/download/${V}/fastfetch-linux-aarch64.tar.gz" \
-                | tar xz --strip-components=1 -C "$HOME/.local/bin" "fastfetch-linux-aarch64/usr/bin/fastfetch"
+                | tar xz --strip-components=3 -C "$HOME/.local/bin" "fastfetch-linux-aarch64/usr/bin/fastfetch"
         fi
         verify_installed fastfetch fastfetch
     fi
@@ -221,7 +221,7 @@ if ! command -v onefetch &>/dev/null; then
     if [ "$ARCH" = "x86_64" ]; then
         if V=$(gh_version "o2sh/onefetch"); then
             curl -sL "https://github.com/o2sh/onefetch/releases/download/${V}/onefetch-linux.tar.gz" \
-                | tar xz -C "$HOME/.local/bin" onefetch
+                | tar xz --strip-components=1 -C "$HOME/.local/bin"
             verify_installed onefetch onefetch
         fi
     elif [ "$ARCH" = "aarch64" ]; then


### PR DESCRIPTION
## Summary
- **fastfetch**: archive path has 3 components (`fastfetch-linux-amd64/usr/bin/fastfetch`) but script used `--strip-components=1`, placing the binary at `~/.local/bin/usr/bin/fastfetch` instead of `~/.local/bin/fastfetch`. Fixed to `--strip-components=3`.
- **onefetch**: archive stores the binary as `./onefetch` (with `./` prefix), so specifying the filename `onefetch` in the tar command fails with "Not found in archive". Fixed by removing the explicit filename and using `--strip-components=1` to strip the leading `./`.

## Test plan
- [ ] Run `chezmoi apply` on a fresh Linux x86_64 machine and confirm both `fastfetch` and `onefetch` are installed to `~/.local/bin/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)